### PR TITLE
Fix val2bool not working with str objects

### DIFF
--- a/bin/ddiskit
+++ b/bin/ddiskit
@@ -455,7 +455,7 @@ def val2bool(val):
         return val
     if isinstance(val, (int, long)):
         return val != 0
-    if isinstance(val, u"".__class__):
+    if isinstance(val, u"".__class__) or isinstance(val, str):
         val = val.lower()
 
         if val in ("t", "y", "true", "yes", "1"):

--- a/templates/spec
+++ b/templates/spec
@@ -21,7 +21,9 @@
 %endif
 
 %if "%{kmod_dist_build_deps}" == ""
-%if (0%{?rhel} > 7) || (0%{?centos} > 7)
+%if (0%{?rhel} > 8) || (0%{?centos} > 8)
+%define kmod_dist_build_deps redhat-rpm-config kernel-abi-stablelists elfutils-libelf-devel kernel-rpm-macros kmod
+%elif (0%{?rhel} > 7) || (0%{?centos} > 7)
 %define kmod_dist_build_deps redhat-rpm-config kernel-abi-whitelists elfutils-libelf-devel kernel-rpm-macros kmod
 %else
 %define kmod_dist_build_deps redhat-rpm-config kernel-abi-whitelists


### PR DESCRIPTION
It seems that in some python versions spec files are not loaded as
unicode.